### PR TITLE
RSDK-5103 Absolutely minimal module template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
-name = "micro-rdk-module-template"
+name = "{{project-name}}"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["{{authors}}"]
+resolver = "2"
 
 [dependencies]
+anyhow = {version = "1", features = ["backtrace"]}
+micro-rdk = {git = "https://github.com/viamrobotics/micro-rdk.git", features = ["{{mcu}}"]}
+
+[package.metadata.com.viam]
+module = true

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,10 @@
+[template]
+cargo_generate_version = ">=0.10.0"
+ignore = [".git","README.md"]
+description = "Micro-RDK Module Template"
+
+[placeholders.mcu]
+type = "string"
+prompt = "MCU"
+choices = ["esp32"]
+default = "esp32"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,5 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+use micro_rdk::common::registry::{ComponentRegistry, RegistryError};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+pub fn register_models(_registry: &mut ComponentRegistry) -> anyhow::Result<(), RegistryError> {
+    Ok(())
 }


### PR DESCRIPTION
As bare bones as it gets. This creates a new template that you can use with `cargo generate` and produces a library crate with a no-op `register_models` entry point, and a `Cargo.toml` that has the required `package.metadata.com.viam.module = true` setting.

I walked @gvaradarajan through it last night and he was able to generate a new project from the robot template, then generate a new module from the module template, and build a bin that he could flash to the esp32. We confirmed that once the new module was added to the `Cargo.toml` for the robot it registered at startup.

I think the decision from here is whether the module template should grow into something more. I could see it, for instance, having support for tests that would run on the esp32. But that would require adding all the necessary infra for starting up the micro-rdk and building/flashing binaries. I'm not sure we want to have that in what would become yet a third location (micro-rdk itself, robot template, and now module template). Actually, perhaps even more than that, since the micro-rdk repo itself has some examples.

My personal feeling is heading towards making `micro-rdk` purely a library crate, and moving all the build / flash smarts into the robot template, and then pulling the examples out? I also have some vague thoughts about whether the rdk and the two templates belong in something more like a workspace monorepo. Anyway, that's getting ahead of things by a long way. For now, this is enough to have a working module auto-reg protocol between the robot template and this new template.